### PR TITLE
增加导出中文的脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.mp3
+*.lrc
+*.csv
+.project
+.pydevproject
+collection.media

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ PS:遗憾的是，Kindle原生系统生词本会保留生词所在例句，多�
 4. 打开Anki，导入生成的Tobeimport.csv，注意分隔符是逗号。我专注听力，所以正面问题是音频，背面答案是英文台词
 
 # ab2anki-zh.py
-在TransDoukanDictToCsv.py基础上修改而来，用法一样，只是在添加了中文释义，并且以```<br>```分隔
+在TransDoukanDictToCsv.py基础上修改而来，用法一样，只是在英文后面添加了中文释义:smile:，并且以```<br>```分隔

--- a/README.md
+++ b/README.md
@@ -21,3 +21,6 @@ PS:遗憾的是，Kindle原生系统生词本会保留生词所在例句，多�
 3. 把所有mp3文件拷贝到Anki存放多媒体文件的目录，类似C:\Users\xxx\Documents\Anki\xxx\collection.media
 
 4. 打开Anki，导入生成的Tobeimport.csv，注意分隔符是逗号。我专注听力，所以正面问题是音频，背面答案是英文台词
+
+# ab2anki-zh.py
+在TransDoukanDictToCsv.py基础上修改而来，用法一样，只是在添加了中文释义，并且以```<br>```分隔

--- a/ab2anki-zh.py
+++ b/ab2anki-zh.py
@@ -1,0 +1,58 @@
+#-*-coding:utf-8-*-
+#Aboboo导出转Anki
+import re
+import os
+import sys
+import csv
+import shutil
+import glob
+import time
+reload(sys)  
+sys.setdefaultencoding('utf8')
+output = "Tobeimport.csv"
+def Main():
+	curpath = os.getcwd()
+	print curpath
+	lrcfiles = curpath + "/*.lrc"
+	mediaPath=curpath+r"/collection.media"
+	#创建collection.media目录
+	if not os.path.exists(mediaPath): 
+		os.makedirs(mediaPath) 
+	flist = glob.glob(lrcfiles)
+	writer = csv.writer(file(output, 'wb+'))
+	pattern1 = re.compile(r'\](.*?)\s*\t')
+	pattern2 = re.compile(r'\t\s*(.*?)$')
+	i = 0
+	for f in flist:
+		i = i + 1
+		fh = file(f,'r')
+		content = fh.read()
+		#进行转码，因为ab导出的lrc文件是系统默认编码，需要转换成Python的Unicode编码
+		content=content.decode('gbk', 'ignore')
+		english = pattern1.findall(content)
+		chinese = pattern2.findall(content)
+		print content
+		print english[0]
+		print chinese[0]
+		mp3file = f[:-3] + "mp3"
+		newname = str(time.time()) + str(i) + ".mp3"
+		print mp3file
+		print newname
+		#把重命名改成复制文件，防止破坏源文件
+		#os.rename(mp3file, newname)
+		shutil.copyfile(mp3file,mediaPath+"/"+newname)
+		question = "[sound:" + newname +"]"
+		if not english:
+			answer =content[10:]
+		elif chinese:
+			#有中文的情况
+			answer = english[0]+"<br>"+chinese[0] + "<br>" + question
+		else:
+			#没有中文的情况
+			answer = english[0]+ "<br>" + question
+		writer.writerow([question, answer])
+		fh.close()
+	del writer
+      
+if __name__ == "__main__":
+	Main()


### PR DESCRIPTION
作者您好，我也是无意中发现这个脚本的，然后我在您原有的ImportAnki -Voice as question.py脚本上修改出了一个an2anki-zh.py的脚本，以及还有一些小修改下面做简要说明。
# an2anki-zh.py
- 名称变短了，命令行模式下运行更方便
- 用法和ImportAnki -Voice as question.py脚本一样
- 把原来的重命名MP3文件机制换成复制到同目录下的collection.media的机制，防止破坏原文件名
- 修复处理中文字符的错误，Aboboo导出的lrc为gbk编码，需要转换
# 其他
- 增加.gitignore文件，忽略MP3和lrc等文件，方便本地测试
- 在README中增加了ab2anki-zh.py的说明